### PR TITLE
Fix auth redirect error

### DIFF
--- a/src/pages/app/offer/[slug].js
+++ b/src/pages/app/offer/[slug].js
@@ -137,15 +137,14 @@ export const AppOfferDetails = ({account}) => {
 }
 
 
-export const getServerSideProps = async ({res}) => {
+export const getServerSideProps = async ({res, resolvedUrl}) => {
     const account = await verifyID(res.req)
-    const redirect = res.req.originalUrl
 
     if(account.exists){
         return {
             redirect: {
                 permanent: true,
-                destination: `/app/auth?callbackUrl=${redirect}`
+                destination: `/app/auth?callbackUrl=${resolvedUrl}`
             }
         }
     }
@@ -154,7 +153,7 @@ export const getServerSideProps = async ({res}) => {
         return {
             redirect: {
                 permanent: true,
-                destination: `/login?callbackUrl=${redirect}`
+                destination: `/login?callbackUrl=${resolvedUrl}`
             }
         }
     }


### PR DESCRIPTION
When the session expires, user gets this page on redirect `/_next/data/rn__06aEjnx689MubfhJ2/app/offer/life-beyond.json?slug=life-beyond`. I checked all other pages to ensure it only exists here.

This only happens when clicking on a offer from the offers page when some auth token expires. Other pages hardcode the URL to redirect to if auth expires.

`res.req.originalUrl` returns `/_next/data/rn__06aEjnx689MubfhJ2/app/offer/life-beyond.json?slug=life-beyond`

Instead using `resolvedUrl` that can be accessed as a prop of getServerSideProps, will return just `/app/offer/life-beyond`