### PR TITLE
Token refresh changes

### DIFF
--- a/server/controllers/login/tokenHelper.js
+++ b/server/controllers/login/tokenHelper.js
@@ -1,0 +1,78 @@
+const moment = require("moment");
+const { serialize } = require("cookie");
+const { jwtVerify, SignJWT } = require("jose");
+
+const authTokenValidityLength = 15; //min
+const refreshTokenValidityLength = 12; //hours
+
+const userIdentification = "userId";
+const JWT_REFRESH_SECRET_encode = new TextEncoder().encode(process.env.JWT_REFRESH_SECRET);
+const JWT_ACCESS_SECRET_encode = new TextEncoder().encode(process.env.JWT_SECRET);
+
+const alg = "HS256";
+const authTokenName = "x-auth-access";
+const refreshTokenName = "x-refresh-access";
+
+const generateToken = async (userData, length, encryption) => {
+    return await new SignJWT({ user: userData })
+        .setProtectedHeader({ alg })
+        .setIssuedAt()
+        .setExpirationTime(length)
+        .sign(encryption);
+};
+
+const buildCookie = (name, content, maxAge) => {
+    return serialize(name, content, {
+        httpOnly: true,
+        secure: process.env.ENV === "production",
+        sameSite: "strict",
+        maxAge: maxAge,
+        path: "/",
+    });
+};
+
+const verifyToken = async (token, secret) => {
+    const { payload } = await jwtVerify(token, secret);
+    if (!payload) throw new Error("Bad JWT");
+    return payload;
+};
+
+const refreshCookies = async (token) => {
+    try {
+        const refreshAuthData = await refreshAuth(token);
+        if (refreshAuthData) {
+            return {
+                ...refreshAuthData,
+                ok: true,
+            };
+        }
+    } catch (error) {
+        console.error("Error refreshing token:", error);
+    }
+    return { ok: false };
+};
+
+const refreshAuth = async ({accessToken, refreshToken}) => {
+    const accessCookie = buildCookie(authTokenName, accessToken, authTokenValidityLength);
+    const refreshCookie = buildCookie(refreshTokenName, refreshToken, refreshTokenValidityLength);
+
+    return {
+        cookie: {
+            refreshCookie,
+            accessCookie,
+        }
+    };
+};
+
+module.exports = {
+    userIdentification,
+    JWT_REFRESH_SECRET_encode,
+    JWT_ACCESS_SECRET_encode,
+    authTokenName,
+    refreshTokenName,
+    generateToken,
+    buildCookie,
+    verifyToken,
+    refreshCookies,
+    refreshAuth,
+};

--- a/server/routes/auth.router.js
+++ b/server/routes/auth.router.js
@@ -5,7 +5,8 @@ const axios = require("axios");
 const logger = require("../../src/lib/logger");
 const { serializeError } = require("serialize-error");
 const { envCache } = require("../controllers/envionment");
-const { verifyID, buildCookie, refreshTokens } = require("../../src/lib/authHelpers");
+const { verifyID, buildCookie, refreshData } = require("../../src/lib/authHelpers");
+const { refreshCookies } = require("../controllers/login/tokenHelper");
 
 //LOGIN USER
 router.post("/login", async (req, res) => {
@@ -22,34 +23,39 @@ router.post("/login", async (req, res) => {
 
         envCache.set(`${req.body.tenant}:${req.body.partner}`, result.env);
 
-        const cookies = [result.cookie.refreshCookie, result.cookie.accessCookie];
+        const session = await refreshCookies(result.token);
+        
+        if (!session?.ok) throw Error("Error generating cookies")
+
+        const cookies = [session.cookie.refreshCookie, session.cookie.accessCookie];
         res.setHeader("Set-Cookie", cookies);
-        delete result.cookie;
         delete result.token;
         delete result.env;
         return res.status(200).json(result);
     } catch (error) {
-        logger.info(`LOGIN USER`, {
-            error: serializeError(error),
-            body: req.body,
-        });
+        logger.info(`LOGIN USER`, { error: serializeError(error), body: req.body });
         return res.status(400).json({});
     }
 });
 
 //LOG OUT
 router.delete("/login", async (req, res) => {
-    const { auth } = await verifyID(req);
-    if (!auth) return res.status(401).json({});
+
 
     try {
-        const token = req.cookies[authTokenName];
-        const auth = await axios.delete(`${process.env.AUTHER}/auth/login`, {
-            data: { token },
-        });
-        const result = auth.data;
-        if (!result?.ok) throw Error("Bad AUTHER response");
-        const cookies = [result.cookie.refreshCookie, result.cookie.accessCookie];
+        if (!req.body.softLogout) {
+            const { auth } = await verifyID(req);
+            if (!auth) return res.status(401).json({});
+
+            const token = req.cookies[authTokenName];
+            const authData = await axios.delete(`${process.env.AUTHER}/auth/login`, { data: { token } });
+            const result = authData.data;
+            if (!result?.ok) throw Error("Bad AUTHER response");
+        }
+
+        const accessCookie = buildCookie(authTokenName, null, -1);
+        const refreshCookie = buildCookie(refreshTokenName, null, -1);
+        const cookies = [refreshCookie, accessCookie];
         res.setHeader("Set-Cookie", cookies);
         return res.status(200).json({ ok: true });
     } catch (error) {
@@ -58,30 +64,40 @@ router.delete("/login", async (req, res) => {
             body: req.body,
             cookie: req.cookies[authTokenName],
         });
-
         const accessCookie = buildCookie(authTokenName, null, -1);
         const refreshCookie = buildCookie(refreshTokenName, null, -1);
-        const cookie = [accessCookie, refreshCookie];
-        res.setHeader("Set-Cookie", cookie);
+        const cookies = [refreshCookie, accessCookie];
+        res.setHeader("Set-Cookie", cookies);
         return res.status(400).json({ ok: false });
     }
 });
+
 
 //REFRESH TOKEN
 router.put("/login", async (req, res) => {
     try {
         const token = req.cookies[refreshTokenName];
         console.log("refresh", token);
-        const refresh = await refreshTokens(token);
 
-        if (!refresh?.ok) throw Error("Bad AUTHER response");
+        if (!token) {
+            return res.status(400).send({ ok: false, error: "Token is required" });
+        }
+
+        const { auth, user } = await verifyID(req, true);
+        if (!auth) return res.status(401).json({ ok: false, error: "Not authorized" });
+
+        const userData = await refreshData(token);
+        if (!userData?.ok) throw Error("Bad AUTHER response");
+        
+        const refresh = await refreshCookies(userData.token);
+        if (!refresh) return res.status(403).json({ ok: false, error: "Refresh failed" });
+
+        if (!refresh?.ok) throw Error("Error generating cookies");
 
         const cookies = [refresh.cookie.refreshCookie, refresh.cookie.accessCookie];
         res.setHeader("Set-Cookie", cookies);
-        delete refresh.data.user;
-        delete refresh.token;
 
-        return res.status(200).json(refresh.data);
+        return res.status(200).json(userData.data);
     } catch (error) {
         logger.error(`ERROR :: REFRESH USER`, {
             error: serializeError(error),

--- a/src/fetchers/auth.fetcher.js
+++ b/src/fetchers/auth.fetcher.js
@@ -4,13 +4,7 @@ import { axiosPrivate } from "@/lib/axios/axiosPrivate";
 
 export const logIn = async (message, signature, tenant, partner, type) => {
     try {
-        const { data } = await axiosPublic.post(API.auth, {
-            message,
-            signature,
-            tenant,
-            partner,
-            type,
-        });
+        const { data } = await axiosPublic.post(API.auth, { message, signature, tenant, partner, type });
         return data;
     } catch (e) {}
     return false;
@@ -19,6 +13,15 @@ export const logIn = async (message, signature, tenant, partner, type) => {
 export const logOut = async () => {
     try {
         const { data } = await axiosPrivate.delete(API.auth);
+        return data;
+    } catch (e) {}
+    return false;
+};
+export const logOutRefresh = async () => {
+    try {
+        const { data } = await axiosPrivate.delete(API.auth, {
+            data: { softLogout: true }
+        });
         return data;
     } catch (e) {}
     return false;

--- a/src/lib/axios/refreshToken.js
+++ b/src/lib/axios/refreshToken.js
@@ -4,7 +4,6 @@ import { axiosPublic } from "./axiosPublic";
 const refreshTokenFn = async () => {
     try {
         const response = await axiosPublic.put("/api/auth/login");
-        console.log("response refres", response);
 
         return response.status === 200;
     } catch (error) {

--- a/src/lib/context/EnvironmentContext.js
+++ b/src/lib/context/EnvironmentContext.js
@@ -5,7 +5,7 @@ import set from "lodash.set";
 import { useAccount, useSwitchChain } from "wagmi";
 import { useRouter } from "next/router";
 import { TENANT } from "@/lib/tenantHelper";
-import { logOut } from "@/fetchers/auth.fetcher";
+import { logOut, logOutRefresh } from "@/fetchers/auth.fetcher";
 import routes from "@/routes";
 
 const DEFAULT_STATE = {
@@ -157,7 +157,7 @@ export const EnvironmentProvider = ({ children, initialData }) => {
 
     useEffect(() => {
         const handleLogoutEvent = () => {
-            environmentCleanup();
+            environmentCleanup(true);
         };
 
         if (typeof window !== "undefined") {
@@ -219,10 +219,10 @@ export const EnvironmentProvider = ({ children, initialData }) => {
         });
     };
 
-    const environmentCleanup = () => {
+    const environmentCleanup = (softLogout) => {
         router.push(routes.Landing).then(async (el) => {
             setEnvironmentProps(DEFAULT_STATE);
-            await logOut();
+            softLogout ? await logOutRefresh() : await logOut()
         });
     };
 


### PR DESCRIPTION
## Summary

- Moved cookie generation for the auth workflow from auther to here.
- Investigated issue with multiple auth refresh failures and implemented soft logout to fix issue with unlimited delete calls.
We had `axiosPrivate` interceptor setup which make an api call to refresh tokens. If this refresh call fails, it makes an api call to logout. Both these api calls check `verifyId` method that validates auth is correct. However, if access tokens expire, then this call will fail. So when the delete api call fails, it goes through the entire process all over again since it uses the same `axiosPrivate` instance to make the delete call. This caused an infinite loop that destroyed the browser because it was making thousands of request / minute. 
The `soft logout` simply deletes all the cookies from the webapp that does not make any authenticated backend calls and follows the logout workflow that the client normally expects.

It showed up as symptoms from our users such as login page does not work after logging out really long after being inactive etc. This issue is present when user logs out after refresh token expires. /user is navigating between different offer in OTC page.

- Updated logging for better root cause analysis of Moralis issues + other errors.

## Related PR
- [Auther changes](https://github.com/SublimeVentures/auther/pull/12)

## Ticket ID/Link to ClickUp

[Link to ClickUp task 1](https://app.clickup.com/t/86azkwk2t)
[Link to ClickUp task 2](https://app.clickup.com/t/86azkwafd)

## Checklist

- [ ] Provided a screenshot (only if change is visible in UI)
- [x] Provided a change scope in summary
- [x] Local Docker build has passed