### PR TITLE
CU-86b00gy3d - Bug:: Scrollbar flickering upon clicking on the overfl…

### DIFF
--- a/src/components/Modal/GenericRightModal.js
+++ b/src/components/Modal/GenericRightModal.js
@@ -32,7 +32,7 @@ export default function GenericRightModal({ isOpen, closeModal, title, content, 
 
     return (
         <Transition appear show={isOpen} as={Fragment}>
-            <Dialog as="div" className="relative z-30" onClose={() => closeModalOnBg()}>
+            <Dialog as="div" className="relative z-30" onClose={closeModalOnBg}>
                 <Transition.Child
                     as={Fragment}
                     enter="ease-out duration-300"


### PR DESCRIPTION
## Summary

- Fixed scrollbar flickering upon clicking on the overflow when the modal is open

### Playback
1. Select "OTC" from the sidebar menu.
2. Click the "Make Offer" button to open the modal window.
3. Click on the background to interact with the modal.

## Ticket ID/Link to ClickUp

[ClickUp](https://app.clickup.com/t/86b00gy3d)

## Checklist

- [x] Provided a screenshot (only if change is visible in UI)
- [x] Provided steps for playback (only if possible).
- [x] Provided a change scope in summary
- [x] Local Docker build has passed

## Videos before and after

https://github.com/SublimeVentures/portal/assets/52605378/dd56837b-747e-4fe4-a3ec-52a7385fa244

https://github.com/SublimeVentures/portal/assets/52605378/6a59b305-081b-499e-bcf9-4c7b0657b753

