### PR TITLE
fix(sidebar): removed max height value from sidebar

### DIFF
--- a/src/components/Layout/LayoutApp.js
+++ b/src/components/Layout/LayoutApp.js
@@ -17,9 +17,7 @@ export default function LayoutApp({ children }) {
     return (
         <div style={{ "--alertHeight": alertHeight }}>
             {isBlockedAlert && (
-                <div
-                    className={`fixed top-0 flex items-center justify-center bg-app-error uppercase text-white font-accent z-[100000] w-full text-center px-5 h-[var(--alertHeight)]`}
-                >
+                <div className="fixed top-0 flex items-center justify-center bg-app-error uppercase text-white font-accent z-[100000] w-full text-center px-5 h-[var(--alertHeight)]">
                     Investments are blocked!&nbsp;
                     <u>
                         <Link href={routes.Settings}>Stake {stakingCurrency?.symbol} to unlock</Link>.
@@ -35,7 +33,14 @@ export default function LayoutApp({ children }) {
                         : "min-h-screen",
                 )}
             >
-                <Sidebar session={children.props?.session} />
+                <div className={cn("sticky top-0 z-20",
+                    isBlockedAlert
+                        ? "max-h-[calc(100vh_-_var(--alertHeight))] top-[var(--alertHeight)]"
+                        : "max-h-screen",
+                    )}
+                >
+                    <Sidebar session={children.props?.session} />
+                </div>
                 <main className="flex flex-col w-full grow sm:min-h-full max-w-[1920px] p-5 mobile:p-10 gap-5 mobile:gap-10 text-app-white">
                     {children}
                 </main>

--- a/src/components/Navigation/Sidebar.js
+++ b/src/components/Navigation/Sidebar.js
@@ -213,7 +213,7 @@ export default function Sidebar({ session }) {
     };
 
     return (
-        <aside className="flex sticky top-0 z-20 collap:relative">
+        <aside className="flex h-full">
             <div className="p-6 flex-col border-r border-app-bg-split boxshadow text-app-white sticky top-0 hidden collap:flex overflow-x-hidden overflow-y-auto">
                 <div className="flex justify-between">
                     <Link href={PAGE.App}>


### PR DESCRIPTION
## Summary

- Removed the max-height style from the sidebar, which was causing an additional scrollbar to appear on the sidebar and was cutting off content on smaller screens.

## Checklist

- [x] Provided a screenshot (only if change is visible in UI)
- [x] Provided a change scope in summary
- [x] Local Docker build has passed

## Video with effects
https://github.com/SublimeVentures/portal/assets/52605378/73d78e01-e70f-411d-8f1c-74039aacf85d



