### PR TITLE
Redone notification query

### DIFF
--- a/server/queries/notifications.query.js
+++ b/server/queries/notifications.query.js
@@ -47,28 +47,7 @@ async function getNotifications(user, query) {
         const last = notifications[notifications.length - 1].id;
         return {
             last,
-            notifications: await Promise.all(
-                notifications.map((notif) => {
-                    switch (notif.typeId) {
-                        case NotificationTypes.MYSTERY_BUY:
-                            return enrichMysteryBuyNotification(notif);
-                        case NotificationTypes.UPGRADE_BUY:
-                            return enrichUpgradeBuyNotification(notif);
-                        case NotificationTypes.OTC_CANCEL:
-                        case NotificationTypes.OTC_MADE:
-                        case NotificationTypes.OTC_TAKE:
-                            return enrichOtcNotification(notif);
-                        case NotificationTypes.INVESTMENT:
-                            return enrichInvestmentNotification(notif);
-                        case NotificationTypes.REFUND:
-                            return enrichReturnNotification(notif);
-                        case NotificationTypes.CLAIM:
-                            return enrichClaimNotification(notif);
-                        default:
-                            return notif;
-                    }
-                }),
-            ),
+            notifications: await buildFullNotifications(notifications),
         };
     } catch (err) {
         console.log("[Notifications] Fetch Error:", err.message);
@@ -77,6 +56,31 @@ async function getNotifications(user, query) {
             notifications: [],
         };
     }
+}
+
+async function buildFullNotifications(baseNotifications) {
+    return Promise.all(
+        baseNotifications.map((notif) => {
+            switch (notif.typeId) {
+                case NotificationTypes.MYSTERY_BUY:
+                    return enrichMysteryBuyNotification(notif);
+                case NotificationTypes.UPGRADE_BUY:
+                    return enrichUpgradeBuyNotification(notif);
+                case NotificationTypes.OTC_CANCEL:
+                case NotificationTypes.OTC_MADE:
+                case NotificationTypes.OTC_TAKE:
+                    return enrichOtcNotification(notif);
+                case NotificationTypes.INVESTMENT:
+                    return enrichInvestmentNotification(notif);
+                case NotificationTypes.REFUND:
+                    return enrichReturnNotification(notif);
+                case NotificationTypes.CLAIM:
+                    return enrichClaimNotification(notif);
+                default:
+                    return notif;
+            }
+        }),
+    );
 }
 
 async function enrichMysteryBuyNotification(plainNotification) {


### PR DESCRIPTION
## Summary

- Fully redone notification query
- Sortable via `?sort=asc` or `?sort=desc`, sorting by ID for the cursor-based pagination
- Cursor-based pagination with `last` response property, indicating last ID of the notification for further fetching with Infinite Query
- Page size managed by `?size=[number]`
- Property-based filtering, e.g. `?typeId=4` will return only notifications of type 4, `?offerId=16` will return only notifications for offer ID = 16, etc.

## Important
Frontend hasn't been adjusted to reflect the newest changes. Currently, instead of direct list, API returns an **object** with properties `last` and `notifications`, with `notifications` being a proper list now.

## Ticket ID/Link to ClickUp

[Link to ClickUp task](https://app.clickup.com/t/86b14hkwj)

## Checklist

- [x] Provided a screenshot (not needed)
- [x] Provided steps for playback (not needed).
- [x] Provided a change scope in summary
- [x] Local Docker build has passed
