### PR TITLE
Adapting t_unlock migration to payouts table

### DIFF
--- a/server/queries/vaults.query.js
+++ b/server/queries/vaults.query.js
@@ -30,6 +30,12 @@ const query_getUserVault = `
     ORDER BY "vault"."createdAt" DESC;
 `;
 
+const query_getPayoutsFromVault = `
+    SELECT "payout".*
+    FROM "payout"
+    WHERE "payout"."offerId" = :offerId
+`;
+
 const query_getUserClaims = `
     SELECT "claim"."isClaimed"
     FROM "claim"
@@ -51,9 +57,14 @@ async function getUserVault(userId, partnerId, tenantId) {
                     type: QueryTypes.SELECT,
                     replacements: { userId, offerId: vault.offerId },
                 });
+                const payouts = await db.query(query_getPayoutsFromVault, {
+                    type: QueryTypes.SELECT,
+                    replacements: { offerId: vault.offerId },
+                });
                 return {
                     ...vault,
                     claims,
+                    payouts,
                 };
             }),
         );

--- a/src/components/App/Vault/VaultItem.js
+++ b/src/components/App/Vault/VaultItem.js
@@ -21,26 +21,24 @@ export default function VaultItem({ item, passData }) {
     const tgeParsed = tge > 0 ? `+${normalized_tgeDiff}%` : "TBA";
 
     const { vestedPercentage, nextUnlock, nextSnapshot, nextClaim, isInstant, isSoon, claimStage, payoutId } =
-        parseVesting(item.t_unlock);
+        parseVesting(item.payouts);
     const awaitingClaim = claims.some((claim) => !claim.isClaimed) && payoutId > 0;
     const performance = (claimed / invested) * 100;
 
-    const setPassData = () => {
-        return {
-            ...item,
-            participated,
-            normalized_tgeDiff,
-            normalized_invested,
-            tgeParsed,
-            vestedPercentage,
-            nextUnlock,
-            nextSnapshot,
-            nextClaim,
-            isInstant,
-            isSoon,
-            claimStage,
-        };
-    };
+    const setPassData = () => ({
+        ...item,
+        participated,
+        normalized_tgeDiff,
+        normalized_invested,
+        tgeParsed,
+        vestedPercentage,
+        nextUnlock,
+        nextSnapshot,
+        nextClaim,
+        isInstant,
+        isSoon,
+        claimStage,
+    });
 
     useEffect(() => {
         VanillaTilt.init(tilt.current, {
@@ -138,6 +136,14 @@ VaultItem.propTypes = {
         claims: PropTypes.arrayOf(
             PropTypes.shape({
                 isClaimed: PropTypes.bool,
+            }),
+        ),
+        payouts: PropTypes.arrayOf(
+            PropTypes.shape({
+                snapshotDate: PropTypes.number,
+                claimDate: PropTypes.number,
+                percentage: PropTypes.number,
+                unlockDate: PropTypes.string,
             }),
         ),
         createdAt: PropTypes.string,

--- a/src/lib/vesting.js
+++ b/src/lib/vesting.js
@@ -29,25 +29,25 @@ export function parseVesting(offerVesting) {
 
         for (let i = 0; i < offerVesting.length; i++) {
             const vesting = offerVesting[i];
-            if (vesting.c === 0) break;
-            if (vesting.c > now) {
-                const unlockDateUnix = moment(vesting.u, "YYYY-MM-DD").unix();
+            if (vesting.claimDate === 0) break;
+            if (vesting.claimDate > now) {
+                const unlockDateUnix = moment(vesting.unlockDate, "YYYY-MM-DD").unix();
                 isSoon =
-                    vesting.c - now <= THREE_DAYS_IN_SECONDS ||
-                    vesting.s - now <= THREE_DAYS_IN_SECONDS ||
+                    vesting.claimDate - now <= THREE_DAYS_IN_SECONDS ||
+                    vesting.snapshotDate - now <= THREE_DAYS_IN_SECONDS ||
                     unlockDateUnix - now <= MONTH_IN_SECONDS;
-                nextUnlock = vesting.u;
-                nextSnapshot = moment.unix(vesting.s).utc().local().format("YYYY-MM-DD mm:SS");
-                nextClaim = moment.unix(vesting.c).utc().local().format("YYYY-MM-DD mm:SS");
+                nextUnlock = vesting.unlockDate;
+                nextSnapshot = moment.unix(vesting.snapshotDate).utc().local().format("YYYY-MM-DD mm:SS");
+                nextClaim = moment.unix(vesting.claimDate).utc().local().format("YYYY-MM-DD mm:SS");
 
-                if (now > unlockDateUnix && vesting.s !== 0) {
+                if (now > unlockDateUnix && vesting.snapshotDate !== 0) {
                     claimStage = STAGES.SNAPSHOT;
-                } else if (now > vesting.s && vesting.c !== 0) {
+                } else if (now > vesting.snapshotDate && vesting.claimDate !== 0) {
                     claimStage = STAGES.CLAIM;
                 }
                 break;
             }
-            vestedPercentage += vesting.p;
+            vestedPercentage += vesting.percentage;
             payoutId = i + 1;
         }
 


### PR DESCRIPTION
## Summary

- Vault has been modified to utilise the update from [db_schema](https://github.com/SublimeVentures/db_schema/pull/36)
- Instead of `t_unlock`, `VaultItem` component now uses `item.payouts`, provided via `payout` table from API

## Ticket ID/Link to ClickUp

[Rewrite t_unlock from offers into payout table](https://app.clickup.com/t/86b1cr8ve)

## Checklist

- [x] Provided a screenshot (not needed)
- [x] Provided steps for playback (not needed)
- [x] Provided a change scope in summary
- [x] Local Docker build has passed
