### PR TITLE
Experimental: self-hosted runner

### DIFF
--- a/.github/workflows/staging.deploy.yml
+++ b/.github/workflows/staging.deploy.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   deploy:
     name: Deploy
-    runs-on: ubuntu-latest
+    runs-on: linux
     if: github.event.pull_request.merged == true
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

- Experimental: Created a self-hosted runner
- Broaded `ubuntu-latest` group temporarily to `linux` (since `ubuntu-latest` is probably there because of our external infrastructure, the change is temporary, to see if runner is able to build the application)

## Checklist

- _Not applicable_