### PR TITLE
fix: navigation active state

### DIFF
--- a/src/v2/components/Layout/Sidebar.js
+++ b/src/v2/components/Layout/Sidebar.js
@@ -28,7 +28,7 @@ export default function Sidebar({ isBlockedAlert = false, className }) {
                                 "text-base font-normal text-white transition-colors hover:bg-primary/30 rounded cursor-pointer",
                                 {
                                     "bg-gradient-to-r from-primary to-primary-600 font-medium":
-                                        router.pathname === path,
+                                        router.pathname.includes(path),
                                 },
                             )}
                         >


### PR DESCRIPTION
## Summary

- I’ve resolved the issue by ensuring that opportunities in the menu are not set to active when you’re already on the opportunities page.

## Ticket ID/Link to ClickUp

[Link to ClickUp task](https://example.org)

## Checklist

- [ ] Provided a screenshot (only if change is visible in UI)
- [ ] Provided steps for playback (only if possible).
- [ ] Provided a change scope in summary
- [ ] Local Docker build has passed
